### PR TITLE
MNEMONIC-517: Update documents to reflect migrated repository to gitbox

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -5,7 +5,7 @@ This directory contains the code for the Apache mnemonic web site,
 
 ## Setup
 
-1. `git clone https://git-wip-us.apache.org/repos/asf/mnemonic.git -b asf-site target`
+1. `git clone https://gitbox.apache.org/repos/asf/mnemonic.git -b asf-site target`
 2. `sudo gem install bundler`
 3. `sudo gem install github-pages jekyll`
 4. `bundle install`

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://garyw@git-wip-us.apache.org/repos/asf/mnemonic-site.git"
+    "url": "https://garyw@gitbox.apache.org/repos/asf/mnemonic-site.git"
   },
   "author": "Gang(Gary) Wang",
   "license": "LicenseRef-LICENSE",

--- a/src/develop/index.md
+++ b/src/develop/index.md
@@ -172,13 +172,13 @@ There are several development mailing lists for mnemonic
 
 mnemonic uses git for version control. Get the source code:
 
-`% git clone https://git-wip-us.apache.org/repos/asf/mnemonic.git`
+`% git clone https://gitbox.apache.org/repos/asf/mnemonic.git`
 
 The important branches are:
 
-* [master](https://git-wip-us.apache.org/repos/asf/mnemonic.git){:target="_blank"} -
+* [master](https://gitbox.apache.org/repos/asf/mnemonic.git){:target="_blank"} -
   The trunk for all development, please find master branch marked in light green.
-* [asf-site](https://git-wip-us.apache.org/repos/asf/mnemonic-site.git){:target="_blank"} -
+* [asf-site](https://gitbox.apache.org/repos/asf/mnemonic-site.git){:target="_blank"} -
   The pages that are deployed to https://mnemonic.apache.org/
 
 Please check our [coding guidelines](coding).

--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -39,7 +39,7 @@ RUN yum -y update && yum -y groupinstall 'Development Tools' && \
 
 RUN gem install jekyll bundler nokogiri
 
-RUN mkdir -p /ws && cd /ws && git clone https://git-wip-us.apache.org/repos/asf/mnemonic-site.git && \
+RUN mkdir -p /ws && cd /ws && git clone https://gitbox.apache.org/repos/asf/mnemonic-site.git && \
     cd mnemonic-site && bundle install
 
 ENV MNEMONIC_SITE_HOME /ws/mnemonic-site

--- a/src/docker/docker-Ubuntu/Dockerfile
+++ b/src/docker/docker-Ubuntu/Dockerfile
@@ -40,7 +40,7 @@ RUN apt-get -y update && \
 
 RUN gem install jekyll bundler nokogiri
 
-RUN mkdir -p /ws && cd /ws && git clone https://git-wip-us.apache.org/repos/asf/mnemonic-site.git && \
+RUN mkdir -p /ws && cd /ws && git clone https://gitbox.apache.org/repos/asf/mnemonic-site.git && \
     cd mnemonic-site && bundle install
 
 ENV MNEMONIC_SITE_HOME /ws/mnemonic-site


### PR DESCRIPTION
Due to recent Apache Gitbox repository migration, some documentation, reference links and Dockerfiles which were pointed to previous git-wip-us needs to be updated.